### PR TITLE
Added passthrough support for Sendable

### DIFF
--- a/Sources/SpecialString/EssentiallyAString.swift
+++ b/Sources/SpecialString/EssentiallyAString.swift
@@ -51,7 +51,7 @@ public extension EssentiallyAString {
 // MARK: - Hashable
 
 public extension EssentiallyAString {
-    public func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         rawValue.hash(into: &hasher)
     }
 }

--- a/Sources/SpecialString/SpecialString.swift
+++ b/Sources/SpecialString/SpecialString.swift
@@ -46,3 +46,13 @@ extension SpecialString: EssentiallyAString {
 public protocol SpecialStringSpecialType {
     // Empty on-purpose; Marker protocol
 }
+
+
+
+// MARK: - Passthrough conformance
+
+// MARK: Concurrency
+
+#if swift(>=5.5)
+extension SpecialString: Sendable where SpecialType: Sendable {}
+#endif


### PR DESCRIPTION
Now if your special string's special type is `Sendable`, then so is your special string